### PR TITLE
feat: Implement TemplateService for simple variable substitution

### DIFF
--- a/backend/src/app/service_layer/template_service.py
+++ b/backend/src/app/service_layer/template_service.py
@@ -1,6 +1,38 @@
+from typing import Any, Dict
+import re
+
 class MissingVariableError(Exception):
-    pass
+    """Custom exception for missing variables in a template."""
+    def __init__(self, variable_name: str):
+        self.variable_name = variable_name
+        super().__init__(f"Missing variable: {variable_name}")
 
+class TemplateService:
+    """Service for rendering templates."""
 
-class TemplateExtensionError(Exception):
-    pass
+    def render(self, template_content: str, variables: Dict[str, Any]) -> str:
+        """
+        Renders a template string with the given variables.
+
+        Args:
+            template_content: The template string with {{variable}} placeholders.
+            variables: A dictionary of variable names to their values.
+
+        Returns:
+            The rendered string.
+
+        Raises:
+            MissingVariableError: If a variable in the template is not found in the variables dict.
+        """
+        # Find all variable placeholders (e.g., {{name}})
+        required_variables = re.findall(r"\{\{(.*?)\}\}", template_content)
+
+        rendered_content = template_content
+        for var_name in required_variables:
+            # Strip whitespace from var_name as re.findall might include it
+            clean_var_name = var_name.strip()
+            if clean_var_name not in variables:
+                raise MissingVariableError(clean_var_name)
+            rendered_content = rendered_content.replace(f"{{{{{var_name}}}}}", str(variables[clean_var_name]))
+        
+        return rendered_content

--- a/backend/tests/service_layer/test_template_service.py
+++ b/backend/tests/service_layer/test_template_service.py
@@ -1,1 +1,57 @@
-# from app.service_layer.template_service import TemplateService, MissingVariableError
+import pytest
+from typing import Dict, Any
+from backend.src.app.service_layer.template_service import TemplateService, MissingVariableError
+
+class TestTemplateService:
+    def test_render_with_simple_variables(self):
+        service = TemplateService()
+        template_content = "Hello {{name}}! Today is {{day}}."
+        variables = {'name': 'World', 'day': 'Monday'}
+        expected_output = "Hello World! Today is Monday."
+        assert service.render(template_content, variables) == expected_output
+
+    def test_render_with_extra_variables(self):
+        service = TemplateService()
+        template_content = "Hello {{name}}!"
+        variables = {'name': 'World', 'day': 'Tuesday'} # 'day' is extra
+        expected_output = "Hello World!"
+        assert service.render(template_content, variables) == expected_output
+
+    def test_render_raises_for_missing_variable(self):
+        service = TemplateService()
+        template_content = "Hello {{name}}! You are {{age}} years old."
+        variables = {'name': 'World'} # 'age' is missing
+        
+        with pytest.raises(MissingVariableError) as excinfo:
+            service.render(template_content, variables)
+        
+        assert excinfo.value.variable_name == "age"
+        assert str(excinfo.value) == "Missing variable: age"
+
+    def test_render_with_empty_template(self):
+        service = TemplateService()
+        template_content = ""
+        variables: Dict[str, Any] = {}
+        expected_output = ""
+        assert service.render(template_content, variables) == expected_output
+
+    def test_render_with_no_variables_in_template(self):
+        service = TemplateService()
+        template_content = "Hello World, no variables here."
+        variables = {'name': 'Test'}
+        expected_output = "Hello World, no variables here."
+        assert service.render(template_content, variables) == expected_output
+
+    def test_render_with_variables_having_leading_trailing_spaces_in_template(self):
+        service = TemplateService()
+        template_content = "Hello {{ name }}! Today is {{day }}. Weather is {{ condition }}."
+        variables = {'name': 'Spacey', 'day': 'Wednesday', 'condition': 'Sunny'}
+        expected_output = "Hello Spacey! Today is Wednesday. Weather is Sunny."
+        assert service.render(template_content, variables) == expected_output
+        
+    def test_render_with_non_string_values(self):
+        service = TemplateService()
+        template_content = "Name: {{name}}, Age: {{age}}, Active: {{is_active}}"
+        variables = {'name': 'Tester', 'age': 30, 'is_active': True}
+        expected_output = "Name: Tester, Age: 30, Active: True"
+        assert service.render(template_content, variables) == expected_output


### PR DESCRIPTION
Implemented `TemplateService` with a `render` method capable of substituting `{{variable}}` placeholders in a template string with provided values.

Key features:
- Handles basic variable replacement.
- Raises a custom `MissingVariableError` if a variable defined in the template is not supplied in the input dictionary. The error message clearly indicates which variable is missing.
- Includes comprehensive unit tests to cover successful rendering, missing variable scenarios, templates with leading/trailing spaces around variable names, non-string variable values, empty templates, and templates without variables.

All tests are passing, and the implementation includes strict typing.